### PR TITLE
Migrate to libdns 1.0 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ func main() {
 
 The `Provider` struct has the following fields:
 
-- `AuthId` (string): Your ClouDNS authentication ID.
+- `AuthId` (string, optional): Your ClouDNS authentication ID.
 - `SubAuthId` (string, optional): Your ClouDNS sub-authentication ID.
 - `AuthPassword` (string): Your ClouDNS authentication password.
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/libdns/cloudns
 
-go 1.20
+go 1.24
 
-require github.com/libdns/libdns v0.2.2
+require github.com/libdns/libdns v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
-github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
+github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/model.go
+++ b/model.go
@@ -1,15 +1,206 @@
 package cloudns
 
+import (
+	"fmt"
+	"net/netip"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/libdns/libdns"
+)
+
 // ApiDnsRecord represents a DNS record retrieved from or sent to the API.
 // It includes fields for record identification, configuration, and status.
 type ApiDnsRecord struct {
-	Id       string `json:"id"`
-	Type     string `json:"type"`
+	Id       string `json:"id"                        parameters:"record-id"`
+	Type     string `json:"type"                      parameters:"record-type"`
 	Host     string `json:"host"`
-	Record   string `json:"record"`
+	Record   string `json:"record,omitempty"`
 	Failover string `json:"failover"`
 	Ttl      string `json:"ttl"`
+	CAAFlag  uint8  `json:"caa_flag,string,omitempty"`
+	CAAType  string `json:"caa_type,omitempty"`
+	CAAValue string `json:"caa_value,omitempty"`
+	Priority uint16 `json:"priority,string,omitempty"`
+	Port     uint16 `json:"port,string,omitempty"`
+	Weight   uint16 `json:"weight,string,omitempty"`
 	Status   int    `json:"status"`
+}
+
+func fromLibdnsRecord(rec libdns.Record, id string) ApiDnsRecord {
+	ttl := strconv.Itoa(ttlRounder(rec.RR().TTL))
+	type_ := rec.RR().Type
+
+	switch impl := rec.(type) {
+	case libdns.Address:
+		return ApiDnsRecord{
+			Id:     id,
+			Ttl:    ttl,
+			Type:   type_,
+			Host:   impl.Name,
+			Record: impl.IP.String(),
+		}
+	case libdns.CAA:
+		return ApiDnsRecord{
+			Id:       id,
+			Ttl:      ttl,
+			Type:     type_,
+			Host:     impl.Name,
+			CAAFlag:  impl.Flags,
+			CAAType:  impl.Tag,
+			CAAValue: impl.Value,
+		}
+
+	case libdns.CNAME:
+		return ApiDnsRecord{
+			Id:     id,
+			Ttl:    ttl,
+			Type:   type_,
+			Host:   impl.Name,
+			Record: impl.Target,
+		}
+
+	case libdns.MX:
+		return ApiDnsRecord{
+			Id:       id,
+			Ttl:      ttl,
+			Type:     type_,
+			Host:     impl.Name,
+			Priority: impl.Preference,
+			Record:   impl.Target,
+		}
+
+	case libdns.NS:
+		return ApiDnsRecord{
+			Id:     id,
+			Ttl:    ttl,
+			Type:   type_,
+			Host:   impl.Name,
+			Record: impl.Target,
+		}
+	case libdns.SRV:
+		return ApiDnsRecord{
+			Id:       id,
+			Ttl:      ttl,
+			Type:     type_,
+			Host:     fmt.Sprintf("_%v._%v.%v", impl.Service, impl.Transport, impl.Name),
+			Priority: impl.Priority,
+			Weight:   impl.Weight,
+			Port:     impl.Port,
+			Record:   impl.Target,
+		}
+	default:
+		rr := rec.RR()
+		return ApiDnsRecord{
+			Id:     id,
+			Ttl:    ttl,
+			Type:   type_,
+			Host:   rr.Name,
+			Record: rr.Data,
+		}
+	}
+}
+
+// toLibdnsRecord translates an upstream API object into a libdns
+// record object.
+func (r ApiDnsRecord) toLibdnsRecord() (libdns.Record, error) {
+	rawttl, err := strconv.Atoi(r.Ttl)
+	if err != nil {
+		return libdns.RR{}, fmt.Errorf("Invalid TTL %q", r.Ttl)
+	}
+	ttl := time.Duration(rawttl) * time.Second
+
+	switch r.Type {
+	case "A", "AAAA":
+		addr, err := netip.ParseAddr(r.Record)
+		if err != nil {
+			return libdns.Address{}, fmt.Errorf("Invalid IP %q: %w", r.Record, err)
+		}
+
+		return libdns.Address{
+			Name: r.Host,
+			TTL:  ttl,
+			IP:   addr,
+		}, nil
+	case "CAA":
+		return libdns.CAA{
+			Name:  r.Host,
+			TTL:   ttl,
+			Flags: r.CAAFlag,
+			Tag:   r.CAAType,
+			Value: r.CAAValue,
+		}, nil
+	case "CNAME":
+		return libdns.CNAME{
+			Name:   r.Host,
+			TTL:    ttl,
+			Target: r.Record,
+		}, nil
+	case "MX":
+		return libdns.MX{
+			Name:       r.Host,
+			TTL:        ttl,
+			Preference: r.Priority,
+			Target:     r.Record,
+		}, nil
+	case "NS":
+		return libdns.NS{
+			Name:   r.Host,
+			TTL:    ttl,
+			Target: r.Record,
+		}, nil
+	case "SRV":
+		parts := strings.SplitN(r.Host, ".", 3)
+		if len(parts) < 3 {
+			return libdns.SRV{}, fmt.Errorf("Name %q does not have enough components (expected >3, got %v)", r.Host, len(parts))
+		}
+		return libdns.SRV{
+			Service:   strings.TrimPrefix(parts[0], "_"),
+			Transport: strings.TrimPrefix(parts[1], "_"),
+			Name:      parts[2],
+			TTL:       ttl,
+			Priority:  r.Priority,
+			Weight:    r.Weight,
+			Port:      r.Port,
+			Target:    r.Record,
+		}, nil
+	case "TXT":
+		return libdns.TXT{
+			Name: r.Host,
+			TTL:  ttl,
+			Text: r.Record,
+		}, nil
+	// HTTPS and SVCB do not appear supported by ClouDNS rn
+	default:
+		return libdns.RR{
+			Name: r.Host,
+			TTL:  ttl,
+			Type: r.Type,
+			Data: r.Record,
+		}, nil
+	}
+}
+
+func (r ApiDnsRecord) toParameters() map[string]string {
+	ret := make(map[string]string)
+
+	val := reflect.ValueOf(r)
+	typ := reflect.TypeOf(r)
+	for idx := range val.NumField() {
+		field := val.Field(idx)
+		if !field.IsZero() {
+			name := typ.Field(idx).Tag.Get("parameters")
+			if name == "" {
+				name = typ.Field(idx).Tag.Get("json")
+				name = strings.Split(name, ",")[0]
+			}
+			ret[name] = fmt.Sprintf("%v", field)
+		}
+	}
+
+	return ret
 }
 
 // ApiResponse represents the structure of a standard response from the API, including status and optional data.

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,115 @@
+package cloudns
+
+import (
+	"errors"
+	"testing"
+)
+
+var records = []ApiDnsRecord{
+	{
+		Id:     "1",
+		Ttl:    "60",
+		Type:   "A",
+		Host:   "example.com",
+		Record: "127.0.0.1",
+	},
+	{
+		Id:     "2",
+		Ttl:    "60",
+		Type:   "AAAA",
+		Host:   "example.com",
+		Record: "::1",
+	},
+	{
+		Id:       "3",
+		Ttl:      "60",
+		Type:     "CAA",
+		Host:     "example.com",
+		CAAFlag:  0,
+		CAAType:  "issue",
+		CAAValue: "bar",
+	},
+	{
+		Id:     "4",
+		Ttl:    "60",
+		Type:   "CNAME",
+		Host:   "example.com",
+		Record: "other.example.com",
+	},
+	{
+		Id:       "5",
+		Ttl:      "60",
+		Type:     "MX",
+		Host:     "example.com",
+		Priority: 1,
+		Record:   "other.example.com",
+	},
+	{
+		Id:     "6",
+		Ttl:    "60",
+		Type:   "NS",
+		Host:   "example.com",
+		Record: "other.example.com",
+	},
+	{
+		Id:       "7",
+		Ttl:      "60",
+		Type:     "SRV",
+		Host:     "_http._tcp.foo.example.com",
+		Priority: 1,
+		Weight:   5,
+		Port:     80,
+		Record:   "other.example.com",
+	},
+	{
+		Id:     "8",
+		Ttl:    "60",
+		Type:   "SSHFP",
+		Host:   "ssh.example.com",
+		Record: "4 1 834B398AFD6CBFD93D06F26D2E23E0BAF6576A9D",
+	},
+}
+
+func TestRoundTrip(t *testing.T) {
+	for _, rec := range records {
+		id := rec.Id
+		libdnsrec, err := rec.toLibdnsRecord()
+		if err != nil {
+			t.Errorf("Error converting record %+v to libdns record: %v", rec, err)
+		}
+
+		newrec := fromLibdnsRecord(libdnsrec, id)
+		if newrec != rec {
+			t.Errorf("Expected newrec == rec: %+v == %+v", newrec, rec)
+		}
+	}
+}
+
+var invalidRecords = map[ApiDnsRecord]error{
+	{
+		Type: "SRV",
+		Ttl:  "60",
+		Host: "_http._tcp",
+	}: errors.New("Name \"_http._tcp\" does not have enough components (expected >3, got 2)"),
+	{
+		Ttl: "foo",
+	}: errors.New("Invalid TTL \"foo\""),
+	{
+		Type:   "AAAA",
+		Ttl:    "60",
+		Record: "foo",
+	}: errors.New("Invalid IP \"foo\": ParseAddr(\"foo\"): unable to parse IP"),
+}
+
+func TestBadConversions(t *testing.T) {
+	for rec, expectedErr := range invalidRecords {
+		libdns, err := rec.toLibdnsRecord()
+		if err == nil {
+			t.Errorf("Expected err not to be nil, got record: %+v", libdns)
+		}
+
+		if err.Error() != expectedErr.Error() {
+			t.Errorf("Expected err == expectedErr: %+v == %+v", err, expectedErr)
+		}
+	}
+}

--- a/provider.go
+++ b/provider.go
@@ -2,10 +2,12 @@ package cloudns
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/libdns/libdns"
 	"strings"
 	"time"
+
+	"github.com/libdns/libdns"
 )
 
 // ClouDNS API docs: https://www.cloudns.net/wiki/article/41/
@@ -33,7 +35,7 @@ const (
 
 // Provider facilitates DNS record manipulation with ClouDNS.
 type Provider struct {
-	AuthId                   string        `json:"auth_id"`
+	AuthId                   string        `json:"auth_id,omitempty"`
 	SubAuthId                string        `json:"sub_auth_id,omitempty"`
 	AuthPassword             string        `json:"auth_password"`
 	PropagationTimeout       time.Duration `json:"propagation_timeout,omitempty"`
@@ -46,18 +48,16 @@ type Provider struct {
 
 // GetRecords lists all the records in the zone.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	if strings.HasSuffix(zone, ".") {
-		zone = strings.TrimSuffix(zone, ".")
-	}
+	zone = strings.TrimSuffix(zone, ".")
 
 	// Use retry mechanism for the GetRecords operation
 	var records []libdns.Record
 	err := RetryWithBackoff(ctx, func() error {
-		var err error
-		records, err = UseClient(p.AuthId, p.SubAuthId, p.AuthPassword).GetRecords(ctx, zone)
-		return err
-	}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
+		var e error
 
+		records, e = UseClient(p.AuthId, p.SubAuthId, p.AuthPassword).GetRecords(ctx, zone)
+		return e
+	}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get records after retries: %w", err)
 	}
@@ -68,34 +68,33 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 // AppendRecords adds records to the zone. It returns the records that were added.
 // It also verifies that the records have properly propagated to DNS servers.
 func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	if strings.HasSuffix(zone, ".") {
-		zone = strings.TrimSuffix(zone, ".")
-	}
+	zone = strings.TrimSuffix(zone, ".")
 
-	var createdRecords []libdns.Record
+	createdRecords := make([]libdns.Record, 0, cap(records))
 	for _, record := range records {
 		// Use retry mechanism for the AddRecord operation
-		var r *libdns.Record
+		var r libdns.Record
 		err := RetryWithBackoff(ctx, func() error {
 			var err error
-			r, err = UseClient(p.AuthId, p.SubAuthId, p.AuthPassword).AddRecord(ctx, zone, record.Type, record.Name, record.Value, record.TTL)
+			r, err = UseClient(p.AuthId, p.SubAuthId, p.AuthPassword).AddRecord(ctx, zone, fromLibdnsRecord(record, ""))
+
 			return err
 		}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
-
 		if err != nil {
-			return nil, fmt.Errorf("failed to add record after retries: %w", err)
+			return nil, fmt.Errorf("failed to add record %q: %w", record.RR().Name, err)
 		}
 
-		createdRecords = append(createdRecords, *r)
+		createdRecords = append(createdRecords, r)
 
 		// For TXT records (commonly used for ACME challenges), verify DNS propagation
-		if record.Type == "TXT" {
+		rr := record.RR()
+		if rr.Type == "TXT" {
 			// Create a context with timeout for propagation verification
 			propagationCtx, cancel := context.WithTimeout(ctx, p.getPropagationTimeout())
 			defer cancel()
 
 			// Construct the FQDN for the record
-			fqdn := record.Name
+			fqdn := rr.Name
 			if fqdn != "" && fqdn != "@" {
 				fqdn = fqdn + "." + zone
 			} else {
@@ -106,12 +105,11 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 			err = VerifyDNSPropagation(
 				propagationCtx,
 				fqdn,
-				record.Type,
-				record.Value,
+				rr.Type,
+				rr.Data,
 				p.getPropagationRetries(),
 				p.getPropagationRetryInterval(),
 			)
-
 			if err != nil {
 				return nil, fmt.Errorf("DNS propagation verification failed for %s: %w", fqdn, err)
 			}
@@ -121,52 +119,48 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	return createdRecords, nil
 }
 
-// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
-// It returns the updated records and verifies that the records have properly propagated to DNS servers.
-func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	if strings.HasSuffix(zone, ".") {
-		zone = strings.TrimSuffix(zone, ".")
+func (p *Provider) processOperation(ctx context.Context, c *Client, zone string, oplist operationEntry) (libdns.Record, error) {
+	var (
+		r   libdns.Record
+		err error
+	)
+
+	switch oplist.op {
+	case addRecord:
+		err = RetryWithBackoff(ctx, func() error {
+			var e error
+			r, e = c.AddRecord(ctx, zone, oplist.record)
+
+			return e
+		}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
+
+	case modifyRecord:
+		err = RetryWithBackoff(ctx, func() error {
+			var e error
+			r, e = c.UpdateRecord(ctx, zone, oplist.record)
+
+			return e
+		}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
+	case deleteRecord:
+		err = RetryWithBackoff(ctx, func() error {
+			var e error
+			r, e = nil, c.DeleteRecord(ctx, zone, oplist.record.Id)
+
+			return e
+		}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
+	default:
+		return nil, fmt.Errorf("unknown operation: %v", oplist.op)
 	}
 
-	var updatedRecords []libdns.Record
-	for _, record := range records {
-		var r *libdns.Record
-		var err error
-
-		if len(record.ID) == 0 {
-			// Create new record with retry mechanism
-			err = RetryWithBackoff(ctx, func() error {
-				var opErr error
-				r, opErr = UseClient(p.AuthId, p.SubAuthId, p.AuthPassword).AddRecord(ctx, zone, record.Type, record.Name, record.Value, record.TTL)
-				return opErr
-			}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
-
-			if err != nil {
-				return nil, fmt.Errorf("failed to add record after retries: %w", err)
-			}
-		} else {
-			// Update existing record with retry mechanism
-			err = RetryWithBackoff(ctx, func() error {
-				var opErr error
-				r, opErr = UseClient(p.AuthId, p.SubAuthId, p.AuthPassword).UpdateRecord(ctx, zone, record.ID, record.Name, record.Value, record.TTL)
-				return opErr
-			}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
-
-			if err != nil {
-				return nil, fmt.Errorf("failed to update record after retries: %w", err)
-			}
-		}
-
-		updatedRecords = append(updatedRecords, *r)
-
+	if oplist.op == addRecord || oplist.op == modifyRecord {
 		// For TXT records (commonly used for ACME challenges), verify DNS propagation
-		if record.Type == "TXT" {
+		if oplist.record.Type == "TXT" {
 			// Create a context with timeout for propagation verification
 			propagationCtx, cancel := context.WithTimeout(ctx, p.getPropagationTimeout())
 			defer cancel()
 
 			// Construct the FQDN for the record
-			fqdn := record.Name
+			fqdn := oplist.record.Host
 			if fqdn != "" && fqdn != "@" {
 				fqdn = fqdn + "." + zone
 			} else {
@@ -177,43 +171,106 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 			err = VerifyDNSPropagation(
 				propagationCtx,
 				fqdn,
-				record.Type,
-				record.Value,
+				oplist.record.Type,
+				oplist.record.Record,
 				p.getPropagationRetries(),
 				p.getPropagationRetryInterval(),
 			)
-
 			if err != nil {
 				return nil, fmt.Errorf("DNS propagation verification failed for %s: %w", fqdn, err)
 			}
 		}
 	}
 
-	return updatedRecords, nil
+	return r, err
+}
+
+// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
+// ClouDNS does not offer an atomic update, so updates here can leave the zone
+// in an inconsistent state upon error. No rollback is attempted.
+//
+// All updates are attempted, even if an error is encountered. All successfully
+// updated records are returned.
+func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	zone = strings.TrimSuffix(zone, ".")
+
+	c := UseClient(p.AuthId, p.SubAuthId, p.AuthPassword)
+	upstreamRecords, err := c.GetClouDNSRecords(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get records for zone %q: %w", zone, err)
+	}
+
+	ret := make([]libdns.Record, 0, cap(records))
+	var retErr error
+	existing := clouDNSRecordsToMap(upstreamRecords)
+	rrsets := libdnsRecordsToMap(records)
+	oplist := makeOperationList(rrsets, existing)
+
+	for _, op := range oplist {
+		rec, err := p.processOperation(ctx, c, zone, op)
+		retErr = errors.Join(retErr, err)
+		if rec != nil {
+			ret = append(ret, rec)
+		}
+	}
+
+	return ret, retErr
+}
+
+func matchDeleteTarget(target, matched libdns.Record) bool {
+	matchedRR := matched.RR()
+	targetRR := target.RR()
+
+	if targetRR.Type != "" && targetRR.Type != matchedRR.Type {
+		return false
+	}
+
+	if targetRR.TTL != 0 && targetRR.TTL != matchedRR.TTL {
+		return false
+	}
+
+	if targetRR.Data != "" && targetRR.Data != matchedRR.Data {
+		return false
+	}
+
+	return true
 }
 
 // DeleteRecords deletes the records from the zone. It returns the records that were deleted.
 func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	if strings.HasSuffix(zone, ".") {
-		zone = strings.TrimSuffix(zone, ".")
+	zone = strings.TrimSuffix(zone, ".")
+
+	c := UseClient(p.AuthId, p.SubAuthId, p.AuthPassword)
+	upstreamRecords, err := c.GetClouDNSRecords(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get records for zone %q: %w", zone, err)
 	}
+
+	keyedRecords := clouDNSRecordsToMap(upstreamRecords)
 
 	var deletedRecords []libdns.Record
 	for _, record := range records {
-		// Use retry mechanism for the DeleteRecord operation
-		var r *libdns.Record
-		err := RetryWithBackoff(ctx, func() error {
-			var err error
-			r, err = UseClient(p.AuthId, p.SubAuthId, p.AuthPassword).DeleteRecord(ctx, zone, record.ID)
-			return err
-		}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
+		rr := record.RR()
+		matchingRecords := keyedRecords[nameAndType{name: rr.Name, type_: rr.Type}]
+		for _, matchingRecord := range matchingRecords {
+			matchedLibdnsRecord, err := matchingRecord.toLibdnsRecord()
+			if err != nil {
+				return nil, err
+			}
 
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete record after retries: %w", err)
-		}
+			if !matchDeleteTarget(record, matchedLibdnsRecord) {
+				continue
+			}
 
-		if r != nil {
-			deletedRecords = append(deletedRecords, *r)
+			// Use retry mechanism for the DeleteRecord operation
+			err = RetryWithBackoff(ctx, func() error {
+				return c.DeleteRecord(ctx, zone, matchingRecord.Id)
+			}, p.getOperationRetries(), p.getInitialBackoff(), p.getMaxBackoff())
+			if err != nil {
+				return nil, fmt.Errorf("failed to delete record %q: %w", matchingRecord.Host, err)
+			}
+
+			deletedRecords = append(deletedRecords, matchedLibdnsRecord)
 		}
 	}
 

--- a/stage.go
+++ b/stage.go
@@ -1,0 +1,117 @@
+package cloudns
+
+import (
+	"iter"
+	"slices"
+
+	"github.com/libdns/libdns"
+)
+
+const (
+	nop = iota
+	addRecord
+	modifyRecord
+	deleteRecord
+)
+
+type operation int
+
+type operationEntry struct {
+	op     operation
+	record ApiDnsRecord
+}
+
+func compareIDlessRecord(a ApiDnsRecord, b ApiDnsRecord) bool {
+	return a.Type == b.Type &&
+		a.Host == b.Host &&
+		a.Record == b.Record &&
+		a.Ttl == b.Ttl &&
+		a.CAAFlag == b.CAAFlag &&
+		a.CAAType == b.CAAType &&
+		a.Priority == b.Priority &&
+		a.Port == b.Port &&
+		a.Weight == b.Weight
+}
+
+// createUpdateOperations processes an existing rrset and a new rrset and comes
+// up with a set of operations to sync them. This could be a lot better,
+// since we'll generate a bunch of update operations if there's a new
+// entry in the middle of the list or if the lists are not sorted.
+func createUpdateOperations(existingRRSet []ApiDnsRecord, desiredRRSet []libdns.RR, deleted map[ApiDnsRecord]bool) []operationEntry {
+	existingIter, existingStop := iter.Pull(slices.Values(existingRRSet))
+	defer existingStop()
+	desiredIter, desiredStop := iter.Pull(slices.Values(desiredRRSet))
+	defer desiredStop()
+	ret := make([]operationEntry, 0, max(len(existingRRSet)+len(desiredRRSet)))
+
+	for {
+		existingRR, existingOk := existingIter()
+		desiredRR, desiredOk := desiredIter()
+		if existingOk && desiredOk {
+			modifiedRR := fromLibdnsRecord(desiredRR, existingRR.Id)
+			if !compareIDlessRecord(existingRR, modifiedRR) {
+				ret = append(ret, operationEntry{
+					op:     modifyRecord,
+					record: modifiedRR,
+				})
+			}
+		}
+
+		if existingOk && !desiredOk {
+			deleted[existingRR] = true
+		}
+
+		if !existingOk && desiredOk {
+			ret = append(ret, operationEntry{
+				op:     addRecord,
+				record: fromLibdnsRecord(desiredRR, ""),
+			})
+		}
+
+		if !existingOk && !desiredOk {
+			break
+		}
+	}
+
+	return ret
+}
+
+func makeOperationList(desired map[nameAndType][]libdns.RR, existing map[nameAndType][]ApiDnsRecord) []operationEntry {
+	ret := make([]operationEntry, 0, len(desired))
+	deleted := make(map[ApiDnsRecord]bool)
+
+	for nt, desiredRRSet := range desired {
+		existingRRSet := existing[nt]
+
+		if len(existingRRSet) == 0 {
+			// create
+			for _, desiredRR := range desiredRRSet {
+				ret = append(ret, operationEntry{
+					op:     addRecord,
+					record: fromLibdnsRecord(desiredRR, ""),
+				})
+			}
+		} else {
+			// update
+			ret = append(
+				ret,
+				createUpdateOperations(
+					existingRRSet,
+					desiredRRSet,
+					deleted,
+				)...,
+			)
+		}
+	}
+
+	// Now prepend all of our deletions so that we don't get any
+	// errors for duplicate records
+	ops := make([]operationEntry, 0, len(deleted)+len(ret))
+	for deletion := range deleted {
+		ops = append(ops, operationEntry{
+			op:     deleteRecord,
+			record: deletion,
+		})
+	}
+	return append(ops, ret...)
+}

--- a/stage_test.go
+++ b/stage_test.go
@@ -1,0 +1,209 @@
+package cloudns
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/libdns/libdns"
+)
+
+type makeOperationListIn struct {
+	desired  map[nameAndType][]libdns.RR
+	existing map[nameAndType][]ApiDnsRecord
+}
+
+var makeOperationListTests = []struct {
+	name string
+	in   makeOperationListIn
+	out  []operationEntry
+}{
+	{
+		name: "no operations",
+		in:   makeOperationListIn{},
+		out:  []operationEntry{},
+	},
+	{
+		name: "remove rrset entry",
+		in: makeOperationListIn{
+			desired: map[nameAndType][]libdns.RR{
+				{name: "example.com", type_: "A"}: {
+					{
+						Name: "example.com",
+						TTL:  time.Duration(60) * time.Second,
+						Data: "192.0.2.3",
+						Type: "A",
+					},
+				},
+			},
+			existing: map[nameAndType][]ApiDnsRecord{
+				{name: "example.com", type_: "A"}: {
+					{
+						Id:     "1",
+						Host:   "example.com",
+						Type:   "A",
+						Record: "192.0.2.1",
+						Ttl:    "60",
+					},
+					{
+						Id:     "2",
+						Host:   "example.com",
+						Type:   "A",
+						Record: "192.0.2.2",
+						Ttl:    "60",
+					},
+				},
+			},
+		},
+		out: []operationEntry{
+			{
+				op: deleteRecord,
+				record: ApiDnsRecord{
+					Id:     "2",
+					Host:   "example.com",
+					Type:   "A",
+					Record: "192.0.2.2",
+					Ttl:    "60",
+				},
+			},
+			{
+				op: modifyRecord,
+				record: ApiDnsRecord{
+					Id:     "1",
+					Host:   "example.com",
+					Type:   "A",
+					Record: "192.0.2.3",
+					Ttl:    "60",
+				},
+			},
+		},
+	},
+	{
+		name: "only touch one rrset",
+		in: makeOperationListIn{
+			desired: map[nameAndType][]libdns.RR{
+				{name: "a.example.com", type_: "AAAA"}: {
+					libdns.RR{
+						Name: "a.example.com",
+						TTL:  time.Duration(60) * time.Second,
+						Type: "AAAA",
+						Data: "2001:db8::1",
+					},
+					libdns.RR{
+						Name: "a.example.com",
+						TTL:  time.Duration(60) * time.Second,
+						Type: "AAAA",
+						Data: "2001:db8::2",
+					},
+					libdns.RR{
+						Name: "a.example.com",
+						TTL:  time.Duration(60) * time.Second,
+						Type: "AAAA",
+						Data: "2001:db8::5",
+					},
+				},
+			},
+			existing: map[nameAndType][]ApiDnsRecord{
+				{name: "a.example.com", type_: "AAAA"}: {
+					ApiDnsRecord{
+						Id:     "1",
+						Host:   "a.example.com",
+						Type:   "AAAA",
+						Record: "2001:db8::1",
+						Ttl:    "60",
+					},
+					ApiDnsRecord{
+						Id:     "2",
+						Host:   "a.example.com",
+						Type:   "AAAA",
+						Record: "2001:db8::2",
+						Ttl:    "60",
+					},
+				},
+				{name: "b.example.com", type_: "AAAA"}: {
+					ApiDnsRecord{
+						Id:     "3",
+						Host:   "b.example.com",
+						Type:   "AAAA",
+						Record: "2001:db8::3",
+						Ttl:    "60",
+					},
+					ApiDnsRecord{
+						Id:     "4",
+						Host:   "b.example.com",
+						Type:   "AAAA",
+						Record: "2001:db8::4",
+						Ttl:    "60",
+					},
+				},
+			},
+		},
+		out: []operationEntry{
+			{
+				op: addRecord,
+				record: ApiDnsRecord{
+					Id:     "",
+					Host:   "a.example.com",
+					Type:   "AAAA",
+					Record: "2001:db8::5",
+					Ttl:    "60",
+				},
+			},
+		},
+	},
+	{
+		name: "add rrset",
+		in: makeOperationListIn{
+			desired: map[nameAndType][]libdns.RR{
+				{name: "foo.example.com", type_: "A"}: {
+					{
+						Name: "foo.example.com",
+						TTL:  time.Duration(60) * time.Second,
+						Data: "192.0.2.3",
+						Type: "A",
+					},
+				},
+			},
+			existing: map[nameAndType][]ApiDnsRecord{
+				{name: "example.com", type_: "A"}: {
+					{
+						Id:     "1",
+						Host:   "example.com",
+						Type:   "A",
+						Record: "192.0.2.1",
+						Ttl:    "60",
+					},
+					{
+						Id:     "2",
+						Host:   "example.com",
+						Type:   "A",
+						Record: "192.0.2.2",
+						Ttl:    "60",
+					},
+				},
+			},
+		},
+		out: []operationEntry{
+			{
+				op: addRecord,
+				record: ApiDnsRecord{
+					Host:   "foo.example.com",
+					Type:   "A",
+					Record: "192.0.2.3",
+					Ttl:    "60",
+				},
+			},
+		},
+	},
+}
+
+func TestMakeOperationList(t *testing.T) {
+	for _, tt := range makeOperationListTests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := makeOperationList(tt.in.desired, tt.in.existing)
+			if !reflect.DeepEqual(out, tt.out) {
+				t.Errorf("actual: %+v\n\nexpected: %+v", out, tt.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This migrates to the new libdns 1.0 API, which has some major changes, such as
excluding provider-specific details from the information passed between
providers and consumers.

This diff also addresses some bugs present as part of the old implementation
that were necessary to meet the new 1.0 API featureset, including the following:

* `SetRecords` would not properly handle RRSets, only modifying the exact record
  specified
* Many record types, like `CAA`, `MX`, `NS` and `SRV` were not supported
  properly, since ClouDNS requires more parameters for these fields.
* If authenticating with a `SubAuthID`, you cannot provide an `AuthID` in the
API call

---

I'm making this a draft PR for now since I want to add some more tests and also rebase in the new retry work that was added. An early review would definitely be appreciated :)